### PR TITLE
Update license.txt dates, and remove readme reference to attribution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ CypressPackageManagerTest provides test cases for this upcoming Package Manager 
 ### License and Copyright
 
 The original work is copyright by GemTalk Systems, but is licensed under the MIT license.
-In other words, you are welcome to use it in anyway you wish, provided the original attribution is maintained.
+In other words, you are welcome to use it in almost any way you wish. See license.txt for details.
 
 ### Acknowledgements
 

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013 GemTalk Systems, LLC
+Copyright (c) 2013-2016 GemTalk Systems, LLC
 Portions are Copyright (c) 1996-2013 Pharo Project and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Open-source wars have been fought over the term "attribution." MIT does not have an attribution clause, so I removed this potentially confusing term from the readme.
